### PR TITLE
feat(postgres-logger): prepare for `%H` strftime

### DIFF
--- a/postgres-logger/Dockerfile
+++ b/postgres-logger/Dockerfile
@@ -12,4 +12,4 @@ ENTRYPOINT ["/usr/local/bin/dumb-init", "--"]
 
 # Expand envvars using sh -c
 # Replace `sh` process with `tail` by using exec
-CMD ["sh", "-c", "for i in $(seq 1 7); do touch ${LOG_DIR}/${LOG_NAME}-$i.log && chown 101:103 ${LOG_DIR}/${LOG_NAME}-$i.log; done && exec tail -q -n+1 -F ${LOG_GLOB}"]
+CMD ["sh", "-c", "for i in $(seq 0 23); do touch ${LOG_DIR}/${LOG_NAME}-$i.log && chown 101:103 ${LOG_DIR}/${LOG_NAME}-$i.log; done && exec tail -q -n+1 -F ${LOG_GLOB}"]


### PR DESCRIPTION
## Description

This PR changes the sequence used to chmod logfiles from "1 to 7" to "0 to 23".

## Motivation 

This is part of a change from daily (day of week, strftime `%a`) log rotation to hourly log rotation (strftime `%H`) in an effort to reduce amount of local storage used for logs.